### PR TITLE
🐛 Attempt to fix selfhug

### DIFF
--- a/src/cogs/ducks_hunting_commands.py
+++ b/src/cogs/ducks_hunting_commands.py
@@ -586,7 +586,7 @@ class DucksHuntingCommands(Cog):
                 if db_you.ping_friendly:
                     allowed_mentions.append(ctx.author)
 
-                if db_target.ping_friendly:
+                if db_target.ping_friendly and ctx.author.id != target.id:
                     allowed_mentions.append(target)
 
             allowed_mentions = discord.AllowedMentions(users=allowed_mentions)


### PR DESCRIPTION
Checking if you are already in the allowed_mentions before adding the target, basically checking if you are the target.