### PR TITLE
Fix brush giving EXP instead of costing EXP

### DIFF
--- a/src/cogs/shopping_commands.py
+++ b/src/cogs/shopping_commands.py
@@ -440,7 +440,7 @@ class ShoppingCommands(Cog):
 
         # We don't want to send a level down message here.
         # https://github.com/DuckHunt-discord/DHV4/issues/41
-        db_hunter.experience -= -ITEM_COST
+        db_hunter.experience -= ITEM_COST
 
         db_hunter.active_powerups["sand"] = 0
         db_hunter.weapon_sabotaged_by = None


### PR DESCRIPTION
The brush would GIVE 7 exp instead of costing 7 exp
Previously, this was fixed on sabotage but it had not been fixed on brush
This PR fixes that